### PR TITLE
Add more guidance about applicable logs

### DIFF
--- a/.github/QA_TEMPLATE/cert_feedback.md
+++ b/.github/QA_TEMPLATE/cert_feedback.md
@@ -69,6 +69,8 @@ Why?:
 ### Logs (If Applicable)
 
 [Logs created during the certification]
+`std out Error logs` (if applicable) to demonstrate any found issues 
+`std out Info logs` highlighting that feature X is working properly
 
 ### General Notes  
 [Any notes]  


### PR DESCRIPTION
To make it as clear as possible to node runners who might want to participate in beta testing, add more details about the kind of logs we're looking for.